### PR TITLE
Fixed ReferenceError

### DIFF
--- a/v3.js
+++ b/v3.js
@@ -212,7 +212,7 @@ const v3 = function(delay){
 		return self;
 	};
 	this.getDelay = function(){
-		return time;
+		return self.time;
 	};
 	this.setDelay = function(t){
 		self.time = t;


### PR DESCRIPTION
When using the latest version of this package, we get the following error when using `.getDelay`:
```
C:\path\to\project\node_modules\node-virustotal\v3.js:215
                return time;
                ^

ReferenceError: time is not defined
    at v3.getDelay (C:\Users\david\Documents\Projekte\virustotal-node-test\node_modules\node-virustotal\v3.js:215:3)
    at Object.<anonymous> (C:\Users\david\Documents\Projekte\virustotal-node-test\app.js:7:34)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runM
```

This happens due to a missing self-reference. I just added it :)